### PR TITLE
use es6 module syntax

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,6 @@
-const Server = require('boardgame.io/server');
-const Matchimals = require('../src/Game');
+import Server from 'boardgame.io/server';
+import Game from '../src/Game';
 
-const app = Server({ games: [Matchimals] });
+const app = Server({ games: [Game] });
 
 app.listen(3333, () => console.log('server running on http://localhost:3333'));


### PR DESCRIPTION
While poking around I noticed that the `game` instance passed to the Server was not defined.

This is somehow a JS module problem. `server/index.js` used node module syntax, but the modules are written in ES6 module style. Serious warning: JS modules are a book with seven seals to me.

With this change, the clients seem to connect OK, however this does not fix multiplayer.

I don't know whether the rename `Matchimals` => `Game` was really necessary, since now using ES6, this should use the default export.